### PR TITLE
Update keycloak admin environment variables

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - '8180:8080'
     environment:
-      - KEYCLOAK_USER=admin
-      - KEYCLOAK_PASSWORD=admin
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
       - DB_VENDOR=h2
     volumes:
       - rems_dev_keycloak-data:/opt/keycloak/data/


### PR DESCRIPTION
Fix docker compose to match non-dev version. This will allow the admin web interface for keycloak to work again.

Fixes issue [REMS-476](https://jira.mitre.org/browse/REMS-476)